### PR TITLE
Deduplicate search results, keeping richest copy

### DIFF
--- a/src/scholar/cli.nw
+++ b/src/scholar/cli.nw
@@ -513,8 +513,30 @@ enrich_providers: Annotated[
         ),
     ),
 ] = None,
+<<deduplication option>>
 <<report option>>
 <<search filter options>>
+@
+
+\subsection{Deduplication option}
+
+The same paper routinely appears more than once in a result set---returned by
+several providers, or repeated across a single provider's paginated pages.
+By default we collapse these into one record, keeping the copy with the most
+metadata (\cref{sec:doi-normalization} in the \texttt{scholar} module).
+The [[--no-dedup]] escape hatch disables this so a user can inspect the raw,
+per-provider results---useful when debugging a provider or auditing what each
+source actually returned:
+
+<<deduplication option>>=
+dedup: Annotated[
+    bool,
+    typer.Option(
+        "--dedup/--no-dedup",
+        help="Deduplicate papers in results, keeping the copy with the "
+             "most metadata. Use --no-dedup for raw per-provider results.",
+    ),
+] = True,
 @
 
 \subsection{Report option}
@@ -598,7 +620,7 @@ Large (or unlimited) searches may take time and consume API quotas, but the
 provider implementations handle paging and rate limiting automatically:
 
 <<execute search and display results>>=
-from scholar import Search, SearchFilters
+from scholar import Search, SearchFilters, SearchResult
 from scholar.providers import get_default_providers
 import sys
 
@@ -686,6 +708,71 @@ class TestSearchCommand:
 
         result = runner.invoke(app, ["search", "test query"])
         assert result.exit_code == 0
+
+    def _mock_duplicate_provider(self, monkeypatch):
+        """Install a provider that returns the same paper twice."""
+        from scholar import providers
+
+        def make_dup():
+            return Paper(title="Dup Paper", authors=["A"], doi="10.1/dup")
+
+        mock_provider = Mock()
+        mock_provider.name = "mock"
+        mock_provider.MAX_LIMIT = None
+        mock_provider.search.return_value = [make_dup(), make_dup()]
+        monkeypatch.setattr(providers, "PROVIDERS", {"mock": mock_provider})
+
+    def test_search_deduplicates_by_default(self, monkeypatch):
+        """A single provider returning a paper twice yields one row."""
+        self._mock_duplicate_provider(monkeypatch)
+        result = runner.invoke(app, ["search", "q", "--format", "csv"])
+        assert result.exit_code == 0
+        assert result.stdout.count("Dup Paper") == 1
+
+    def test_search_no_dedup_keeps_duplicates(self, monkeypatch):
+        """--no-dedup preserves duplicate papers from a provider."""
+        self._mock_duplicate_provider(monkeypatch)
+        result = runner.invoke(
+            app, ["search", "q", "--no-dedup", "--format", "csv"]
+        )
+        assert result.exit_code == 0
+        assert result.stdout.count("Dup Paper") == 2
+
+    def test_enrich_processes_every_result_set(self, monkeypatch):
+        """--enrich --no-dedup enriches each provider's result set, not just
+        the first."""
+        from scholar import providers
+        import scholar.enrich as enrich_mod
+
+        prov_a = Mock(name="a")
+        prov_a.name = "a"
+        prov_a.MAX_LIMIT = None
+        prov_a.search.return_value = [
+            Paper(title="Alpha", authors=["A"], doi="10.1/alpha")
+        ]
+        prov_b = Mock(name="b")
+        prov_b.name = "b"
+        prov_b.MAX_LIMIT = None
+        prov_b.search.return_value = [
+            Paper(title="Beta", authors=["B"], doi="10.1/beta")
+        ]
+        monkeypatch.setattr(providers, "PROVIDERS", {"a": prov_a, "b": prov_b})
+
+        seen = []
+
+        def fake_enrich(papers, **kwargs):
+            seen.extend(p.title for p in papers)
+            return list(papers)
+
+        monkeypatch.setattr(enrich_mod, "enrich_papers", fake_enrich)
+        monkeypatch.setattr(enrich_mod, "needs_enrichment", lambda p, f: True)
+
+        result = runner.invoke(
+            app, ["search", "q", "--no-dedup", "--enrich", "--format", "csv"]
+        )
+        assert result.exit_code == 0
+        # Both providers' result sets were sent through enrichment.
+        assert set(seen) == {"Alpha", "Beta"}
 @
 
 \subsection{Merging results from multiple providers}
@@ -699,15 +786,25 @@ For example, a paper found in both DBLP (no abstract) and Semantic Scholar
 (with abstract) will appear once with the abstract from Semantic Scholar.
 The [[source]] field tracks which providers found the paper.
 
+Cross-provider [[merge]] already deduplicates, but it only runs when more than
+one provider responds.
+A single provider can also return the same paper twice (across paginated
+pages), so when [[dedup]] is enabled we additionally call [[deduplicate]] on
+the lone result---guaranteeing a duplicate-free list in every case.
+With [[--no-dedup]] we skip all of this and hand back the raw per-provider
+results untouched, since merging is itself what removes duplicates.
+
 <<merge search results>>=
 from functools import reduce
 
-if len(results) > 1:
+if not dedup:
+    merged_results = results
+elif len(results) > 1:
     logger.info(f"Merging {len(results)} result sets")
     merged = reduce(lambda a, b: a.merge(b), results)
     merged_results = [merged]
 elif len(results) == 1:
-    merged_results = results
+    merged_results = [results[0].deduplicate()]
 else:
     logger.warning("No search results returned")
     merged_results = []
@@ -725,6 +822,10 @@ abstracts) alongside other providers.
 We show a progress indicator since enrichment requires API calls for each paper
 that is missing requested metadata.
 
+We enrich every result set rather than just the first.
+With [[--dedup]] (the default) there is a single merged set, but [[--no-dedup]]
+leaves one set per provider, and all of them deserve enrichment.
+
 The [[--enrich-providers]] option overrides which providers are tried and in
 which order.
 For example, to restrict enrichment to Semantic Scholar and OpenAlex:
@@ -735,26 +836,28 @@ if enrich and merged_results:
     from scholar.enrich import enrich_papers, needs_enrichment
     from rich.progress import Progress
 
-    # Count papers that need enrichment
-    papers = merged_results[0].papers
     enrich_fields = ["abstract", "pdf_url", "keywords"]
-    papers_to_enrich = [p for p in papers if needs_enrichment(p, enrich_fields)]
-
     providers_for_enrich = (
         [p.strip() for p in enrich_providers.split(",") if p.strip()]
         if enrich_providers
         else None
     )
 
-    if papers_to_enrich:
+    # Enrich every result set. With --dedup there is a single merged set;
+    # with --no-dedup there may be one per provider, all of which need it.
+    for i, result in enumerate(merged_results):
+        papers = result.papers
+        if not any(needs_enrichment(p, enrich_fields) for p in papers):
+            continue
+
         with Progress() as progress:
             task = progress.add_task(
                 "[cyan]Enriching papers...",
                 total=len(papers),
             )
 
-            def update_progress(current: int, total: int) -> None:
-                progress.update(task, completed=current)
+            def update_progress(current: int, total: int, _task=task) -> None:
+                progress.update(_task, completed=current)
 
             enriched = enrich_papers(
                 papers,
@@ -762,12 +865,12 @@ if enrich and merged_results:
                 providers=providers_for_enrich,
                 progress_callback=update_progress,
             )
-            merged_results[0] = SearchResult(
-                query=merged_results[0].query,
-                provider=merged_results[0].provider,
-                timestamp=merged_results[0].timestamp,
+            merged_results[i] = SearchResult(
+                query=result.query,
+                provider=result.provider,
+                timestamp=result.timestamp,
                 papers=enriched,
-                filters=merged_results[0].filters,
+                filters=result.filters,
             )
 @
 

--- a/src/scholar/scholar.nw
+++ b/src/scholar/scholar.nw
@@ -74,7 +74,7 @@ Scholar package for structured literature searches.
 """
 
 from .scholar import Search, SearchResult, Paper, SearchFilters
-from .scholar import search, filter_papers
+from .scholar import search, filter_papers, deduplicate_papers
 from .scholar import get_registry, isolated_registry
 from .utils import safe_get_nested, ensure_list
 
@@ -85,6 +85,7 @@ __all__ = [
     "SearchFilters",
     "search",
     "filter_papers",
+    "deduplicate_papers",
     "get_registry",
     "isolated_registry",
     "safe_get_nested",
@@ -560,7 +561,8 @@ When merging results from multiple databases, we need to identify duplicate
 papers.
 We use a two-tier identity system:
 \begin{enumerate}
-\item If both papers have a DOI, compare DOIs (case-insensitive).
+\item If both papers have a DOI, compare their \emph{normalized} DOIs
+  (\cref{sec:doi-normalization}).
 \item Otherwise, compare normalized title combined with the first author's
   last name.
 \end{enumerate}
@@ -570,6 +572,43 @@ This matches the identity used by the Paper Registry, ensuring that
 
 The [[id]] property returns a stable string identifier for a paper.
 This is used as the key in the Paper Registry and for persistent storage.
+
+\subsubsection{Normalizing DOIs}
+\label{sec:doi-normalization}
+
+Providers report the same DOI in inconsistent forms: a bare
+[[10.1000/xyz]], a [[doi:]]-prefixed string, or a full
+[[https://doi.org/10.1000/xyz]] resolver URL.
+If we compared these verbatim, one paper indexed by two providers would land
+under different identities and slip past deduplication---defeating the very
+purpose of a DOI as a stable identifier.
+We therefore canonicalize a DOI before using it as identity: lowercase it,
+trim surrounding whitespace, and strip any resolver prefix so that all three
+spellings above collapse to the single key [[doi:10.1000/xyz]].
+
+<<paper methods>>=
+@staticmethod
+def _normalize_doi(doi: str) -> str:
+    """Return a canonical form of ``doi`` for identity comparison.
+
+    Lowercases, trims whitespace, and removes any resolver prefix
+    (e.g. ``https://doi.org/`` or ``doi:``) so that the same DOI in
+    different spellings compares equal.
+    """
+    normalized = doi.strip().lower()
+    for prefix in DOI_RESOLVER_PREFIXES:
+        if normalized.startswith(prefix):
+            return normalized[len(prefix):]
+    return normalized
+<<constants>>=
+DOI_RESOLVER_PREFIXES = (
+    "https://doi.org/",
+    "http://doi.org/",
+    "https://dx.doi.org/",
+    "http://dx.doi.org/",
+    "doi:",
+)
+@
 
 \paragraph{Performance optimization.}
 The [[id]] property computes a SHA256 hash from the paper's title and first
@@ -596,7 +635,7 @@ def id(self) -> str:
         A string identifier unique to this paper's identity.
     """
     if self.doi:
-        return f"doi:{self.doi.lower()}"
+        return f"doi:{self._normalize_doi(self.doi)}"
 
     # Normalize title
     title_normalized = self.title.lower().strip()
@@ -906,6 +945,66 @@ def merge_with(self, other: "Paper") -> "Paper":
     )
 @
 
+\subsubsection{Scoring metadata richness}
+
+[[merge_with]] is deliberately asymmetric: for [[authors]], [[references]],
+and [[citations]] it keeps [[self]]'s value \emph{wholesale} whenever [[self]]
+has one, rather than unioning.
+This is the right call for those fields---half an author list is worse than a
+complete one---but it means the \emph{order} in which two duplicates are
+merged decides which paper's author list survives.
+To honour \enquote{keep the one with the most metadata}, the caller must merge
+\emph{onto} the richer copy.
+[[metadata_score]] gives that ordering: it counts how many fields a paper has
+populated, weighting [[authors]] by length so a five-author record outscores a
+one-author stub of the same paper.
+The absolute value is meaningless; only the comparison between two duplicates
+matters.
+
+<<paper methods>>=
+@property
+def metadata_score(self) -> int:
+    """Return a rough count of populated metadata fields.
+
+    Used to decide which of two equal papers should be the base when
+    merging, so the richer copy's wholesale-preferred fields survive.
+    Higher means more complete; the absolute value is not meaningful.
+    """
+    score = len(self.authors)
+    for value in (
+        self.title, self.year, self.doi, self.abstract, self.venue,
+        self.url, self.pdf_url, self.citation_count, self.keywords,
+        self.tags, self.references, self.citations,
+    ):
+        if value:
+            score += 1
+    return score
+@
+
+Let's verify that a richer paper outscores a sparser duplicate:
+
+<<test functions>>=
+class TestPaperMetadataScore:
+    """Tests for Paper.metadata_score ordering."""
+
+    def test_richer_paper_scores_higher(self):
+        """A paper with more populated fields scores higher."""
+        with isolated_registry():
+            sparse = Paper(title="Test", authors=["A"], doi="10.1/test")
+            rich = Paper(
+                title="Test", authors=["A"], doi="10.1/test",
+                abstract="abstract", venue="Venue", year=2024,
+            )
+            assert rich.metadata_score > sparse.metadata_score
+
+    def test_more_authors_scores_higher(self):
+        """More authors raise the score for otherwise-equal papers."""
+        with isolated_registry():
+            few = Paper(title="Test", authors=["A"], doi="10.1/test")
+            many = Paper(title="Test", authors=["A", "B", "C"], doi="10.1/test")
+            assert many.metadata_score > few.metadata_score
+@
+
 \subsubsection{Testing paper equality}
 
 Let's verify that paper equality and hashing work correctly for deduplication.
@@ -955,6 +1054,15 @@ class TestPaper:
         with isolated_registry():
             paper = Paper(title="Test", authors=["A"], doi="10.1234/TEST")
             assert paper.id == "doi:10.1234/test"
+
+    def test_paper_id_strips_doi_resolver_prefix(self):
+        """DOIs with a resolver URL prefix normalize to the bare DOI."""
+        with isolated_registry():
+            bare = Paper(title="A", authors=["X"], doi="10.1234/test")
+            url = Paper(title="B", authors=["Y"], doi="https://doi.org/10.1234/TEST")
+            prefixed = Paper(title="C", authors=["Z"], doi=" DOI:10.1234/test ")
+            assert bare.id == url.id == prefixed.id == "doi:10.1234/test"
+            assert bare == url == prefixed
 
     def test_paper_id_without_doi(self):
         """Paper ID uses hash of title+author when no DOI."""
@@ -1696,43 +1804,103 @@ class SearchResult:
 The [[filters]] dictionary captures any provider-specific constraints (date
 ranges, document types, etc.) that were applied.
 
+\subsubsection{Consolidating a list of papers}
+
+Deduplication has the same shape whether the duplicates come from two
+different providers or from a single provider returning the same paper twice
+across paginated pages.
+We extract that shape into one function, [[deduplicate_papers]], so both the
+cross-provider [[merge]] and the single-result [[deduplicate]] share exactly
+one notion of identity and one tie-break rule---rather than drifting apart as
+the earlier code did, where merging deduplicated but a lone result did not.
+
+The function keys a dictionary by paper identity (\cref{sec:doi-normalization})
+so equal papers collapse onto one entry.
+On a collision it merges \emph{onto the richer copy}: the paper with the higher
+[[metadata_score]] becomes [[self]] in [[merge_with]], so its
+wholesale-preferred author list survives while the per-field union still fills
+any gaps from the other copy.
+This is what makes deduplication keep \enquote{the one with the most
+metadata} regardless of the order papers arrive in.
+
+<<functions>>=
+def deduplicate_papers(papers: list[Paper]) -> list[Paper]:
+    """Consolidate duplicate papers, keeping the richest copy of each.
+
+    Papers sharing an identity are merged into a single record. The copy
+    with the higher ``metadata_score`` is used as the merge base so its
+    wholesale-preferred fields (authors, references, citations) survive,
+    while other fields are unioned. Among copies with equal scores, the
+    first-seen value of any conflicting field is kept, mirroring
+    ``Paper.merge_with``. The returned list preserves first-seen order of
+    unique papers.
+    """
+    paper_map: dict[Paper, Paper] = {}
+    for paper in papers:
+        existing = paper_map.get(paper)
+        if existing is None:
+            paper_map[paper] = paper
+        elif paper.metadata_score > existing.metadata_score:
+            paper_map[paper] = paper.merge_with(existing)
+        else:
+            paper_map[paper] = existing.merge_with(paper)
+    return list(paper_map.values())
+@
+
 \subsubsection{Combining results}
 
-We can merge results from multiple searches, deduplicating and consolidating
-papers.
-When the same paper appears from multiple providers, we consolidate the data
-to get the most complete record (keeping abstracts, DOIs, etc.\ from whichever
-source has them).
+Merging two results concatenates their papers and consolidates the combined
+list.
+When the same paper appears from multiple providers, this yields the most
+complete record (keeping abstracts, DOIs, etc.\ from whichever source has
+them).
 
 <<search result methods>>=
 def merge(self, other: "SearchResult") -> "SearchResult":
     """Merge two search results, deduplicating and consolidating papers."""
-    logger.debug(f"Merging search results: {len(self.papers)} + {len(other.papers)} papers")
-    
-    # Use dict keyed by paper identity to enable consolidation
-    paper_map: dict[Paper, Paper] = {}
-
-    for paper in self.papers:
-        paper_map[paper] = paper
-
-    duplicates = 0
-    for paper in other.papers:
-        if paper in paper_map:
-            # Consolidate with existing paper
-            paper_map[paper] = paper_map[paper].merge_with(paper)
-            duplicates += 1
-        else:
-            paper_map[paper] = paper
-
-    merged_count = len(paper_map)
-    logger.info(f"Merged results: {merged_count} unique papers ({duplicates} duplicates removed)")
-
+    logger.debug(
+        f"Merging search results: {len(self.papers)} + "
+        f"{len(other.papers)} papers"
+    )
+    combined = self.papers + other.papers
+    deduped = deduplicate_papers(combined)
+    duplicates = len(combined) - len(deduped)
+    logger.info(
+        f"Merged results: {len(deduped)} unique papers "
+        f"({duplicates} duplicates removed)"
+    )
     return SearchResult(
         query=f"{self.query} | {other.query}",
         provider=f"{self.provider}, {other.provider}",
         timestamp=self.timestamp,
-        papers=list(paper_map.values()),
+        papers=deduped,
         filters=None,
+    )
+@
+
+\subsubsection{Deduplicating a single result}
+
+A single provider can also return the same paper more than once---most often
+when its results are paginated.
+[[deduplicate]] applies the same consolidation to one result's own papers, so
+the search command can guarantee a duplicate-free list even when only one
+provider responded (\cref{sec:doi-normalization}).
+
+<<search result methods>>=
+def deduplicate(self) -> "SearchResult":
+    """Return a copy with this result's own duplicate papers consolidated."""
+    deduped = deduplicate_papers(self.papers)
+    duplicates = len(self.papers) - len(deduped)
+    logger.info(
+        f"Deduplicated {self.provider}: {len(deduped)} unique papers "
+        f"({duplicates} duplicates removed)"
+    )
+    return SearchResult(
+        query=self.query,
+        provider=self.provider,
+        timestamp=self.timestamp,
+        papers=deduped,
+        filters=self.filters,
     )
 @
 
@@ -1797,6 +1965,55 @@ class TestSearchResult:
             # And combined sources
             assert "dblp" in merged.papers[0].sources
             assert "s2" in merged.papers[0].sources
+
+    def test_merge_keeps_richest_authors_regardless_of_order(self):
+        """The fuller author list survives no matter which side it is on."""
+        with isolated_registry():
+            sparse = Paper(title="P", authors=["Smith"], doi="10.1/p")
+            rich = Paper(
+                title="P", authors=["Jane Smith", "John Doe"], doi="10.1/p"
+            )
+            r_sparse = SearchResult(
+                query="q", provider="a", timestamp="t", papers=[sparse]
+            )
+            r_rich = SearchResult(
+                query="q", provider="b", timestamp="t", papers=[rich]
+            )
+            # Richer copy wins whether it is the left or right operand.
+            assert r_sparse.merge(r_rich).papers[0].authors == rich.authors
+            assert r_rich.merge(r_sparse).papers[0].authors == rich.authors
+
+    def test_deduplicate_consolidates_within_one_result(self):
+        """A single result with repeated papers is deduplicated."""
+        with isolated_registry():
+            # Same paper twice, each carrying complementary metadata.
+            first = Paper(
+                title="P", authors=["A"], doi="10.1/p", sources=["dblp"]
+            )
+            second = Paper(
+                title="P", authors=["A"], doi="10.1/p",
+                abstract="Abstract", sources=["s2"]
+            )
+            result = SearchResult(
+                query="q", provider="dblp",
+                timestamp="t", papers=[first, second]
+            )
+            deduped = result.deduplicate()
+            assert len(deduped.papers) == 1
+            assert deduped.papers[0].abstract == "Abstract"
+            assert set(deduped.papers[0].sources) == {"dblp", "s2"}
+
+    def test_deduplicate_keeps_unique_papers(self):
+        """Distinct papers are left untouched by deduplicate."""
+        with isolated_registry():
+            result = SearchResult(
+                query="q", provider="dblp", timestamp="t",
+                papers=[
+                    Paper(title="A", authors=["X"]),
+                    Paper(title="B", authors=["Y"]),
+                ],
+            )
+            assert len(result.deduplicate().papers) == 2
 @
 
 


### PR DESCRIPTION
## Summary

Automatically deduplicate papers in `scholar search` results, always keeping the copy with the **most metadata**. Previously duplicates were only collapsed when *more than one provider* responded, and the merge was order-biased rather than richness-based — so a single provider returning the same paper twice (e.g. across paginated pages) slipped through.

## Changes

- **Robust DOI identity** — `Paper._normalize_doi` strips resolver prefixes (`https://doi.org/`, `doi:`, …) and whitespace, so the same DOI in different spellings shares one identity and deduplicates.
- **Richest-copy wins** — `Paper.metadata_score` counts populated fields (weighting authors by length) to choose the merge *base*, so the fuller author list survives rather than whichever copy happened to come first.
- **One shared dedup primitive** — `deduplicate_papers()`, reused by the refactored `SearchResult.merge` (cross-provider) and the new `SearchResult.deduplicate` (single result). This closes the single-provider gap and gives both paths one identity rule and one tie-break.
- **`--dedup/--no-dedup` flag** (default on). `--no-dedup` returns raw per-provider results for auditing/debugging.

## Incidental fixes (surfaced while wiring this up)

- Enrichment now processes **every** result set, not just the first — needed because `--no-dedup` can leave one set per provider.
- The `search` command now imports `SearchResult`, which the enrich path used but never imported in that scope — a latent `NameError` on `search --enrich` that no test had previously exercised.

## Testing

- New unit tests: DOI-prefix normalization, `metadata_score` ordering, order-independent richest-author retention, single-result `deduplicate`, and the `--dedup`/`--no-dedup`/`--enrich`-all-sets CLI behaviors.
- Full suite: **493 passed, 7 skipped**. (The 5 `snowball`/`tuxedo` subcommand tests fail only because those submodules aren't initialized in this worktree — unrelated to this change.)
- End-to-end smoke test confirms cross-provider dedup, DOI normalization, richest-copy retention, per-field union, and source merging work together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)